### PR TITLE
to_hex_string optionally leaves out spaces for readability

### DIFF
--- a/hex_string.gemspec
+++ b/hex_string.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "hex_string"
-  s.version     = "1.0.0"
+  s.version     = "1.0.1"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["David Crosby", "Micah Alles"]
   s.email       = ["crosby@atomicobject.com", "alles@atomicobject.com"]

--- a/lib/hex_string.rb
+++ b/lib/hex_string.rb
@@ -32,8 +32,13 @@ module HexString
   # Eg:
   #   >> "hello world".to\_hex\_string
   #   => "68 65 6c 6c 6f 20 77 6f 72 6c 64"
-	def to_hex_string
-    self.unpack('H*').first.gsub(/(..)/,'\1 ').rstrip
+	def to_hex_string(readable = true)
+    unpacked = self.unpack('H*').first
+    if readable
+      unpacked.gsub(/(..)/,'\1 ').rstrip
+    else
+      unpacked
+    end
 	end
 end
 

--- a/test/hex_string_test.rb
+++ b/test/hex_string_test.rb
@@ -50,6 +50,10 @@ class HexStringTest < Test::Unit::TestCase
 		assert_equal "68 65 6c 6c 6f", "hello".to_hex_string
 	end
 
+	should "convert byte strings into a single hex string without spaces" do
+		assert_equal "68656c6c6f", "hello".to_hex_string(false)
+	end
+
 	should "provide empty hex strings when operating on empty strings" do 
 	  assert_equal "", "".to_hex_string
 	end


### PR DESCRIPTION
Hi guys - this gem was useful for me today - thanks!

I added a very small change to allow to_hex_string to produce a long hex string with no spaces. This was useful to help URL encode a complex string that contained slashes and other punctuation.

cheers - pat
